### PR TITLE
Improve color contrast to meet WCAG 2.0 AA

### DIFF
--- a/src/core.css
+++ b/src/core.css
@@ -68,7 +68,7 @@ p {
 }
 
 :global a.btn {
-  color: white;
+  color: var(--darkBlue);
   font-size: 0.8rem;
   background: var(--realBtnGreen);
   border-radius: 2rem;

--- a/src/variables.css
+++ b/src/variables.css
@@ -18,7 +18,8 @@
   --bgTealLight: rgb(75, 118, 134);
   --bgOutline: rgb(137, 167, 177);
 
-  --realBrightGreen: rgb(185,219,111);
+  --realBrightGreen: #bee076;
   --realBtnGreen: rgb(140,170,29);
   --semiBlack: rgb(31, 28, 30);
+  --darkBlue: #183352;
 }


### PR DESCRIPTION
I separated this from the other PR because it's a design change (and it's not as big of a deal as the other a11y issues). This adjusts the colors of buttons and links (mostly) to pass WCAG 2.0 AA color standards, which is a pretty good goalpost. This meant brightening up the bright green color very slightly (you can't really tell the difference, I think), and changing the white button color to a dark blue instead:

<img width="1439" alt="screen shot 2017-05-19 at 4 55 07 pm" src="https://cloud.githubusercontent.com/assets/808159/26270924/5a6f3ca2-3cb4-11e7-8c4d-5a9f9505cfe8.png">
