### PR TITLE
fix typo on index.html

### DIFF
--- a/app/pages/index.html
+++ b/app/pages/index.html
@@ -8,7 +8,7 @@
         <p>RSVP for an <a target="_blank" href="https://ti.to/event-loop/">upcoming meetup</a>, everyone is welcome!</p>
         <h2>Giving a Talk</h2>
         <p>No matter who you are and what your experience level is, you can give a talk at SeattleJS. We accept everything from
-            5-10 lightning talks to ~30 minute presentations. If you've learned something new or have some hard-won widsom to
+            5-10 minute lightning talks to ~30 minute presentations. If you've learned something new or have some hard-won widsom to
             share, you'll find SeattleJS a warm and welcoming place to speak.</p>
         <p>Fill-out <a target="_blank" href="https://airtable.com/shrkvVTP37PnIqgoN">this form</a> and we'll be in touch!</p>
         <h2>Sponsors</h2>


### PR DESCRIPTION
Looks like a typo, although the original is valid english, just has a different meaning. Seems like we're talking about presentation time though, so might be a worthwhile change?

### Original:
```
We accept everything from 5-10 lightning talks to ~30 minute presentations.
```
### Revised:
```
We accept everything from 5-10 minute lightning talks to ~30 minute presentations.
```