### PR TITLE
Add meta description tag

### DIFF
--- a/app/head.mjs
+++ b/app/head.mjs
@@ -11,6 +11,7 @@ export default function Head(state) {
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>SeattleJS ${title ? ` - ${title}` : ``}</title>
+        <meta name="description" content="SeattleJS is the largest JavaScript and web developer meetup in Seattle. Our meetings are the 2nd Wednesday of each month. We are an inclusive community and welcome everyone, including folks who are just getting started in tech.">
         <link rel="stylesheet" href="/_public/styles/main.css">
         <link rel="icon" href="/_public/favicon.ico">
         <link rel="stylesheet" href="https://use.typekit.net/nln6hzq.css">


### PR DESCRIPTION
Add a `<meta name="description" />` to our HTML head to improve our search tagline. Currently the search result in Google looks like the following. I'm hoping this meta description will change that.

<img width="653" alt="image" src="https://user-images.githubusercontent.com/459878/223977153-f0764b4e-2da9-4be5-95bd-3fe0a6c95cb2.png">
