### PR TITLE
Return status code 404 when page isn't found

### DIFF
--- a/app/api/$$.mjs
+++ b/app/api/$$.mjs
@@ -15,6 +15,7 @@ export async function get(req) {
   )
   if (!existsSync(filePath)) {
     return {
+      statusCode: 404,
       json: {
         path,
         notFound: true

--- a/app/pages/$$.mjs
+++ b/app/pages/$$.mjs
@@ -5,25 +5,14 @@ import { marked } from 'marked'
  */
 export default function ({ html, state }) {
   let { store } = state
-  let { attributes, body, notFound } = store
+  let { attributes, body } = store
   let title = attributes?.title
-  // if the path did not resolve to a markdown file on the file system
-  if (notFound) {
-    return html`
-      <my-layout>
-        <my-404></my-404>
-      </my-layout>
-    `
-  }
-  // if it did resolve to a markdown file
-  else {
-    return html` <my-layout>
-      <div id="page">
-        <div class="page-title">
-          <div><h1>${title}</h1></div>
-        </div>
-        <div class="page-body">${marked(body)}</div>
+  return html` <my-layout>
+    <div id="page">
+      <div class="page-title">
+        <div><h1>${title}</h1></div>
       </div>
-    </my-layout>`
-  }
+      <div class="page-body">${marked(body)}</div>
+    </div>
+  </my-layout>`
 }

--- a/app/pages/404.html
+++ b/app/pages/404.html
@@ -1,0 +1,3 @@
+<my-layout>
+  <my-404></my-404>
+</my-layout>


### PR DESCRIPTION
Currently when we don't find a page, we return a 200 status code. This PR updates our server to return a 404 when a page isn't found to prevent it from going into browser's history, from being indexed, etc. We still get our cute 404 doggo :)

<img width="1410" alt="image" src="https://user-images.githubusercontent.com/459878/223979451-1110c73b-aeab-466c-a73d-658416c19968.png">
