### PR TITLE
Make Courier URI https

### DIFF
--- a/app/data/sponsors.json
+++ b/app/data/sponsors.json
@@ -60,7 +60,7 @@
   {
     "id": "courier",
     "name": "Courier",
-    "url": "http://courier.com?utm_campaign=devrel-meetups&utm_source=meetups&utm_medium=website",
+    "url": "https://courier.com?utm_campaign=devrel-meetups&utm_source=meetups&utm_medium=website",
     "image": "courier.png",
     "copy": ""
   }


### PR DESCRIPTION
This is not necessary because the http uri redirects to the https uri, but thought I'd make the PR so we can fix it in any case.