### PR TITLE
Speaker page fixes

### DIFF
--- a/app/elements/person-detail.mjs
+++ b/app/elements/person-detail.mjs
@@ -11,6 +11,7 @@ export default function PersonDetail({ html, state = {} }) {
         margin: 8px 0 16px 0;
       }
       .photo img {
+        max-width: none;
         height: 300px;
         width: 300px;
       }

--- a/app/pages/speakers/$id.mjs
+++ b/app/pages/speakers/$id.mjs
@@ -2,7 +2,7 @@ export default function ({ html, state = {} }) {
   let { store = {} } = state
   let { speaker } = store
   return html`
-    <page-layout title=${speaker.name}>
+    <page-layout>
       <pre>${JSON.stringify(speaker, null, 2)}</pre>
     </page-layout>
   `

--- a/app/pages/talks/$id.mjs
+++ b/app/pages/talks/$id.mjs
@@ -24,7 +24,7 @@ export default function ({ html, state = {} }) {
           padding:8px;
       }
     </style>
-    <page-layout title=${talk.title}>      
+    <page-layout>      
       <h2>${ title }</h2>
       <div class="topics">${ topics.map(t => `<div class=topic>${ t }</div>`).join('') }</div>
       <div class="abstract">${ marked.parse(abstract) }</div>


### PR DESCRIPTION
* Remove broken title attribute that was creating new HTML attributes per word in title
* Prevent speaker images for squishing out of proportion on certain screen sizes

Before:
![image](https://github.com/seattlejs/seattlejs.com/assets/459878/d95fad0f-2ab6-47f6-8c48-d143f49621b2)

After:
![image](https://github.com/seattlejs/seattlejs.com/assets/459878/08d8eedc-3ec0-4c1a-baa7-11ab919d2ffb)
