### PR TITLE
Allow additional organizer sites

### DIFF
--- a/app/data/organizers.json
+++ b/app/data/organizers.json
@@ -2,20 +2,29 @@
   {
     "id": "carter-rabasa",
     "full_name": "Carter Rabasa",
-    "twitter": "crtr0"
+    "links": {
+      "twitter": "crtr0"
+    }
   },
   {
     "id": "justin-oliver-lee",
     "full_name": "Justin Oliver Lee",
-    "twitter": "JustinOliverLee"
+    "links": {
+      "twitter": "JustinOliverLee"
+    }
   },
   {
     "id": "andre-wiggins",
     "full_name": "Andre Wiggins",
-    "twitter": "andre_wiggins"
+    "links": {
+      "twitter": "andre_wiggins"
+    }
   },
   {
     "id": "fx-wood",
-    "full_name": "FX Wood"
+    "full_name": "FX Wood",
+    "links": {
+      "github": "fx-wood"
+    }
   }
 ]

--- a/app/elements/list-links.mjs
+++ b/app/elements/list-links.mjs
@@ -1,0 +1,31 @@
+export default function ListLinks({ html, state = {} }) {
+  const { attrs } = state
+  const { links } = attrs
+
+  return html`
+    <style>
+      ul {
+        list-style: none;
+        margin: 8px 0 0 0;
+        padding: 0;
+      }
+    </style>
+    <ul>
+      ${links?.linkedin
+        ? `<li class="links-list"><i class="fab fa-linkedin" style="width: 20px;"></i><a target="_blank" href="https://www.linkedin.com/in/${links.linkedin}">${links.linkedin}</a></li>`
+        : ''}
+      ${links?.twitter
+        ? `<li class="links-list"><i class="fab fa-x-twitter" style="width: 20px;"></i><a target="_blank" href="https://twitter.com/${links.twitter}">@${links.twitter}</a></li>`
+        : ''}
+      ${links?.url
+        ? `<li class="links-list"><i class="fa fa-globe" style="width: 20px;"></i><a target="_blank" href="${url}">${
+            url.split('://')[1]
+          }</a></li>`
+        : ''}
+      ${links?.github
+        ? `<li class="links-list"><i class="fab fa-github" style="width: 20px;"></i><a target="_blank" href="https://github.com/${links.github}">${links.github}</a></li>`
+        : ''}
+    </ul>
+  `
+}
+

--- a/app/elements/list-links.mjs
+++ b/app/elements/list-links.mjs
@@ -1,7 +1,7 @@
 export default function ListLinks({ html, state = {} }) {
   const { attrs } = state
   const { links } = attrs
-
+  const { linkedin, twitter, url, github } = { ...links }
   return html`
     <style>
       ul {
@@ -11,21 +11,20 @@ export default function ListLinks({ html, state = {} }) {
       }
     </style>
     <ul>
-      ${links?.linkedin
-        ? `<li class="links-list"><i class="fab fa-linkedin" style="width: 20px;"></i><a target="_blank" href="https://www.linkedin.com/in/${links.linkedin}">${links.linkedin}</a></li>`
+      ${linkedin
+        ? `<li class="links-list"><i class="fab fa-linkedin" style="width: 20px;"></i><a target="_blank" href="https://www.linkedin.com/in/${linkedin}">${linkedin}</a></li>`
         : ''}
-      ${links?.twitter
-        ? `<li class="links-list"><i class="fab fa-x-twitter" style="width: 20px;"></i><a target="_blank" href="https://twitter.com/${links.twitter}">@${links.twitter}</a></li>`
+      ${twitter
+        ? `<li class="links-list"><i class="fab fa-x-twitter" style="width: 20px;"></i><a target="_blank" href="https://twitter.com/${twitter}">@${twitter}</a></li>`
         : ''}
-      ${links?.url
+      ${url
         ? `<li class="links-list"><i class="fa fa-globe" style="width: 20px;"></i><a target="_blank" href="${url}">${
             url.split('://')[1]
           }</a></li>`
         : ''}
-      ${links?.github
-        ? `<li class="links-list"><i class="fab fa-github" style="width: 20px;"></i><a target="_blank" href="https://github.com/${links.github}">${links.github}</a></li>`
+      ${github
+        ? `<li class="links-list"><i class="fab fa-github" style="width: 20px;"></i><a target="_blank" href="https://github.com/${github}">${github}</a></li>`
         : ''}
     </ul>
   `
 }
-

--- a/app/elements/list-organizers.mjs
+++ b/app/elements/list-organizers.mjs
@@ -35,12 +35,11 @@ export default function ListOrganizers({ html, state = {} }) {
           </p>
           <p>
             <div class="name">${o.full_name}</div>
-            ${o.role ? `${ o.role } <br />` : ''}
-            ${o.twitter
-              ? `<a target="_blank" href="https://twitter.com/${o.twitter}">@${o.twitter}</a></p>`
-              : ''}
+            ${o.role ? `${o.role} <br />` : ''}
+            <list-links links=${o.links}></list-links>
           </p>
         </div>`
       )
       .join('')}
-`}
+  `
+}

--- a/app/elements/person-detail.mjs
+++ b/app/elements/person-detail.mjs
@@ -1,6 +1,7 @@
 export default function PersonDetail({ html, state = {} }) {
   const { attrs } = state
-  let { name, company, twitter, photo, pronouns, location, url, linkedin } = attrs
+  let { name, company, twitter, photo, pronouns, location, url, linkedin } =
+    attrs
   let links = { twitter, url, linkedin }
   return html`
     <style>
@@ -24,21 +25,21 @@ export default function PersonDetail({ html, state = {} }) {
           display: flex;
         }
         .more {
-          margin-left:24px;
+          margin-left: 24px;
         }
       }
     </style>
-    <h2>About ${ name }</h2>
-    <div class="info"> 
-        <div class="photo"><img src="${ photo }" alt="photo of ${ name }"/></div>
-        <div class="more">
-            ${ pronouns && `<h3>Pronouns</h3><p>${ pronouns }</p>` }
-            ${ location && `<h3>Location</h3><p>${ location }</p>` }
-            ${ company && `<h3>Company</h3><p>${ company }</p>` }
-            ${ (twitter || url || linkedin) && html`
-            <h3>Links</h3>
-            <list-links links=${ links }></list-links>` }
-        </div>
+    <h2>About ${name}</h2>
+    <div class="info">
+      <div class="photo"><img src="${photo}" alt="photo of ${name}" /></div>
+      <div class="more">
+        ${pronouns && `<h3>Pronouns</h3><p>${pronouns}</p>`}
+        ${location && `<h3>Location</h3><p>${location}</p>`}
+        ${company && `<h3>Company</h3><p>${company}</p>`}
+        ${(twitter || url || linkedin) &&
+        html` <h3>Links</h3>
+          <list-links links=${links}></list-links>`}
+      </div>
     </div>
   `
 }

--- a/app/elements/person-detail.mjs
+++ b/app/elements/person-detail.mjs
@@ -1,7 +1,7 @@
 export default function PersonDetail({ html, state = {} }) {
   const { attrs } = state
   let { name, company, twitter, photo, pronouns, location, url, linkedin } = attrs
-  //console.log(attrs)
+  let links = { twitter, url, linkedin }
   return html`
     <style>
       h3 {
@@ -35,14 +35,9 @@ export default function PersonDetail({ html, state = {} }) {
             ${ pronouns && `<h3>Pronouns</h3><p>${ pronouns }</p>` }
             ${ location && `<h3>Location</h3><p>${ location }</p>` }
             ${ company && `<h3>Company</h3><p>${ company }</p>` }
-            ${ (twitter || url || linkedin) && `
+            ${ (twitter || url || linkedin) && html`
             <h3>Links</h3>
-            <ul>
-            ${ linkedin ? `<li><i class="fab fa-linkedin"></i> <a target="_blank" href="https://www.linkedin.com/in/${ linkedin }">${ linkedin }</a></li>` : '' }
-            ${ twitter ? `<li><i class="fab fa-twitter"></i> <a target="_blank" href="https://twitter.com/${ twitter }">@${ twitter }</a></li>` : '' }
-            ${ url ? `<li><i class="fa fa-globe"></i> <a target="_blank" href="${ url }">${ url.split("://")[1] }</a></li>` : '' }
-            </ul>
-            `}
+            <list-links links=${ links }></list-links>` }
         </div>
     </div>
   `


### PR DESCRIPTION
I wanted to support using other sites for organizers. In my case I wanted my link to be to GitHub.

## Summary of changes
1. made new component `list-links.mjs` that is reusable for listing 1 to some number of links
2. added component to list-organizers
3. added component to person-detail
4. updated fx's links

Before: 
![image](https://github.com/seattlejs/seattlejs.com/assets/40310772/5ed0b8f3-4239-4aa8-b5af-0f7aa88d922e)

After:
![image](https://github.com/seattlejs/seattlejs.com/assets/40310772/47564282-51e6-47a6-8539-ba8e15ed576f)

What it looks like with multiple links:
![image](https://github.com/seattlejs/seattlejs.com/assets/40310772/87fdc676-3f79-476f-9c35-a8d031050405)



/conf/speaker is (almost) the same
![image](https://github.com/seattlejs/seattlejs.com/assets/40310772/e818b80f-c6c6-46ba-bf06-1f76e5dbc086)

![image](https://github.com/seattlejs/seattlejs.com/assets/40310772/a2ae63fe-ff34-4cbf-94c1-d9738091d72e)


