### PR TITLE
Add email template page

### DIFF
--- a/app/api/events/$id.mjs
+++ b/app/api/events/$id.mjs
@@ -2,9 +2,10 @@ import events from '../../data/events.json' assert { type: 'json' }
 import  { inflateEvent } from '../events.mjs'
 
 export async function get(req) {
-  let { path } = req
+  let { path, query } = req
   const event = events.find(e => e.id === req.params.id)
-
+  let display = "page"
+  if (query && Object.hasOwn(query, "email")) display = "email"
   if (!event) {
     return {
       statusCode: 404,
@@ -24,7 +25,8 @@ export async function get(req) {
     json: {
       events: inflatedEvent,
       sponsors: eventSponsors,
-      talks: eventTalks
+      talks: eventTalks,
+      display
     }
   }}
 }

--- a/app/api/events/$id.mjs
+++ b/app/api/events/$id.mjs
@@ -1,11 +1,11 @@
 import events from '../../data/events.json' assert { type: 'json' }
-import { inflateEvent } from '../events.mjs'
+import  { inflateEvent } from '../events.mjs'
 
 export async function get(req) {
   let { path, query } = req
   const event = events.find(e => e.id === req.params.id)
-  let display = 'page'
-  if (query && Object.hasOwn(query, 'email')) display = 'email'
+  let display = "page"
+  if (query && Object.hasOwn(query, "email")) display = "email"
   if (!event) {
     return {
       statusCode: 404,
@@ -15,19 +15,18 @@ export async function get(req) {
       }
     }
   } else {
-    // We have to convert event from an object to an array to inflate it
-    let inflatedEvent = [event].map(inflateEvent)
-    let eventSponsors = event.sponsors
-    let eventTalks = event.talks
+  // We have to convert event from an object to an array to inflate it
+  let inflatedEvent = [event].map(inflateEvent)
+  let eventSponsors = event.sponsors
+  let eventTalks = event.talks
 
-    // In event/$id we are reusing the element <list-talks> which expects a list of events
-    return {
-      json: {
-        events: inflatedEvent,
-        sponsors: eventSponsors,
-        talks: eventTalks,
-        display
-      }
+  // In event/$id we are reusing the element <list-talks> which expects a list of events
+  return {
+    json: {
+      events: inflatedEvent,
+      sponsors: eventSponsors,
+      talks: eventTalks,
+      display
     }
-  }
+  }}
 }

--- a/app/api/events/$id.mjs
+++ b/app/api/events/$id.mjs
@@ -1,11 +1,11 @@
 import events from '../../data/events.json' assert { type: 'json' }
-import  { inflateEvent } from '../events.mjs'
+import { inflateEvent } from '../events.mjs'
 
 export async function get(req) {
   let { path, query } = req
   const event = events.find(e => e.id === req.params.id)
-  let display = "page"
-  if (query && Object.hasOwn(query, "email")) display = "email"
+  let display = 'page'
+  if (query && Object.hasOwn(query, 'email')) display = 'email'
   if (!event) {
     return {
       statusCode: 404,
@@ -15,18 +15,19 @@ export async function get(req) {
       }
     }
   } else {
-  // We have to convert event from an object to an array to inflate it
-  let inflatedEvent = [event].map(inflateEvent)
-  let eventSponsors = event.sponsors
-  let eventTalks = event.talks
+    // We have to convert event from an object to an array to inflate it
+    let inflatedEvent = [event].map(inflateEvent)
+    let eventSponsors = event.sponsors
+    let eventTalks = event.talks
 
-  // In event/$id we are reusing the element <list-talks> which expects a list of events
-  return {
-    json: {
-      events: inflatedEvent,
-      sponsors: eventSponsors,
-      talks: eventTalks,
-      display
+    // In event/$id we are reusing the element <list-talks> which expects a list of events
+    return {
+      json: {
+        events: inflatedEvent,
+        sponsors: eventSponsors,
+        talks: eventTalks,
+        display
+      }
     }
-  }}
+  }
 }

--- a/app/pages/events/$id.mjs
+++ b/app/pages/events/$id.mjs
@@ -1,4 +1,4 @@
-import { marked } from 'marked'
+import { marked } from "marked"
 
 export default function ({ html, state = {} }) {
   let { store = {} } = state
@@ -7,60 +7,31 @@ export default function ({ html, state = {} }) {
   let { id, title, sponsors, talks, description, date } = event
   let hasTalks = talks && talks.length > 0
   let hasSponsors = sponsors && sponsors.length > 0
-  if (display === 'email') {
+  if (display === "email") {
     let eventDate = new Date(date)
     let htmlContents = `
       <p>GREETING TEXT</p>
       <!-- sponsor -->
-      ${
-        hasSponsors
-          ? sponsors
-              .map(
-                s => `
+      ${hasSponsors ? sponsors.map(s => `
         <p>
           <a href="${s.url}"><img width="200" alt="${s.name} logo" src="https://seattlejs.com/_public/images/sponsors/${s.image}" title="${s.name} logo"></a>
         </p>
         <p>Special thanks to our friends at <a href="URL">${s.name}</a> for sponsoring snacks for this month's event! 😎</p>
-      `
-              )
-              .join('')
-          : null
-      }
+      `).join('') : null}
       <ul>
-        <li>🗓 ${eventDate.toLocaleDateString(undefined, {
-          weekday: 'long',
-          month: 'long',
-          day: 'numeric'
-        })}</li>
+        <li>🗓 ${eventDate.toLocaleDateString(undefined, {weekday: "long", month: "long", day: "numeric"})}</li>
         <li>⏰ 5:30pm - 8:30pm</li>
         <li>📍 LOCATION</li>
         <li>🎟 <a href="https://ti.to/event-loop/">Buy Tickets</a></li>
       </ul>
       <! -- loop through talks -->
-      ${
-        hasTalks
-          ? talks
-              .map(
-                t => `
-          <h4 style="font-family: headline-gothic-atf-round, sans-serif; font-weight: 700; font-size: 24px;">${
-            t.title
-          } by ${t.speaker.name}</h4>
-          <p><img width="200" alt="${
-            t.name
-          }" src="https://seattlejs.com/_public/images/speakers/${
-                  t.speaker.photo
-                }" title="${t.speaker.name}"></p>
-          ${description && `<p>${marked(description)}</p>`}
-        `
-              )
-              .join('')
-          : null
-      }
+      ${hasTalks ? talks.map(t => `
+          <h4 style="font-family: headline-gothic-atf-round, sans-serif; font-weight: 700; font-size: 24px;">${t.title} by ${t.speaker.name}</h4>
+          <p><img width="200" alt="${t.name}" src="https://seattlejs.com/_public/images/speakers/${t.speaker.photo}" title="${t.speaker.name}"></p>
+          ${description && `<p>${marked(description)}</p>` }
+        `).join('') : null }
       <!-- end loop -->
-      <p>See you all on ${eventDate.toLocaleDateString(undefined, {
-        month: 'long',
-        day: 'numeric'
-      })}</p>
+      <p>See you all on ${eventDate.toLocaleDateString(undefined, {month: "long", day: "numeric"})}</p>
     `
     return html`
       <style>
@@ -73,27 +44,25 @@ export default function ({ html, state = {} }) {
         <button id="copy-html-btn">Copy HTML to clipboard</button>
         ${htmlContents}
         <script>
-          const copyHTML = async () => {
-            console.log(\`${htmlContents}\`)
-            await navigator.clipboard.writeText(\`${htmlContents}\`)
-          }
-          window.addEventListener('DOMContentLoaded', () => {
-            const htmlButton = document.getElementById('copy-html-btn')
-            htmlButton.addEventListener('click', copyHTML)
-          })
+         const copyHTML = async () => {
+          console.log(\`${htmlContents}\`)
+          await navigator.clipboard.writeText(\`${htmlContents}\`);
+        }
+        window.addEventListener("DOMContentLoaded", () => {
+          const htmlButton = document.getElementById("copy-html-btn")
+          htmlButton.addEventListener("click", copyHTML)
+        })
         </script>
       </div>
     `
   }
   return html`
-    <page-layout title=${title}>
+  <page-layout title=${title}>
       <h3>${title}</h3>
-      ${description && `<p>${marked(description)}</p>`}
+      ${description && `<p>${marked(description)}</p>` }
       <h4>Thanks to our Sponsors ❤️</h4>
       ${hasSponsors ? html`<list-sponsors></list-sponsors>` : null}
-      ${hasTalks
-        ? html`<list-talks event_id="${id}"></list-talks>`
-        : html`<p>No talks were given durring this event.</p>`}
+      ${hasTalks ? html`<list-talks event_id="${id}"></list-talks>`: html`<p>No talks were given durring this event.</p>`}
       <div class="">
         <a target="_self" href="/events">
           See all past events <i class="fa-solid fa-arrow-right"></i>
@@ -102,3 +71,4 @@ export default function ({ html, state = {} }) {
     </page-layout>
   `
 }
+

--- a/app/pages/events/$id.mjs
+++ b/app/pages/events/$id.mjs
@@ -46,7 +46,7 @@ export default function ({ html, state = {} }) {
           <! -- loop through talks -->
           ${hasTalks ? talks.map(t => `
               <h4 style="font-family: headline-gothic-atf-round, sans-serif; font-weight: 700; font-size: 24px;">${t.title} by ${t.speaker.name}</h4>
-              <p><img width="200" alt="${t.title}" src="https://seattlejs.com/_public/images/speakers/${t.speaker.photo}" title="${t.speaker.name}"></p>
+              <p><img width="200" alt="photo of ${t.speaker.name}" src="https://seattlejs.com/_public/images/speakers/${t.speaker.photo}" title="${t.speaker.name}"></p>
               ${description && `<p>${marked(description)}</p>` }
             `).join('') : null }
           <!-- end loop -->

--- a/app/pages/events/$id.mjs
+++ b/app/pages/events/$id.mjs
@@ -9,8 +9,6 @@ export default function ({ html, state = {} }) {
   let hasSponsors = sponsors && sponsors.length > 0
   if (display === "email") {
     let eventDate = new Date(date)
-    let htmlContents = `
-    `
     return html`
       <style>
         .container {
@@ -51,7 +49,7 @@ export default function ({ html, state = {} }) {
         }
         window.addEventListener("DOMContentLoaded", () => {
           const htmlButton = document.getElementById("copy-html-btn")
-          htmlButton.addEventListener("click", copyHTML2)
+          htmlButton.addEventListener("click", copyHTML)
         })
         </script>
       </div>
@@ -72,4 +70,3 @@ export default function ({ html, state = {} }) {
     </page-layout>
   `
 }
-

--- a/app/pages/events/$id.mjs
+++ b/app/pages/events/$id.mjs
@@ -4,7 +4,17 @@ export default function ({ html, state = {} }) {
   let { store = {} } = state
   let event = store.events[0]
   let display = store.display
-  let { id, title, sponsors, talks, description, date } = event
+  let DEFAULT_LOCATION = "The Collective Seattle, 400 Dexter Ave N, Seattle, WA 98109"
+  let {
+    id,
+    title,
+    sponsors,
+    talks,
+    description,
+    date,
+    location=DEFAULT_LOCATION
+  } = event
+
   let hasTalks = talks && talks.length > 0
   let hasSponsors = sponsors && sponsors.length > 0
   if (display === "email") {
@@ -30,7 +40,7 @@ export default function ({ html, state = {} }) {
           <ul>
             <li>🗓 ${eventDate.toLocaleDateString(undefined, {weekday: "long", month: "long", day: "numeric"})}</li>
             <li>⏰ 5:30pm - 8:30pm</li>
-            <li>📍 LOCATION</li>
+            <li>📍 ${location}</li>
             <li>🎟 <a href="https://ti.to/event-loop/">Buy Tickets</a></li>
           </ul>
           <! -- loop through talks -->

--- a/app/pages/events/$id.mjs
+++ b/app/pages/events/$id.mjs
@@ -6,7 +6,6 @@ export default function ({ html, state = {} }) {
   let display = store.display
   let { id, title, sponsors, talks, description, date } = event
   let hasTalks = talks && talks.length > 0
-  console.log({hasTalks})
   let hasSponsors = sponsors && sponsors.length > 0
   if (display === "email") {
     let eventDate = new Date(date)

--- a/app/pages/events/$id.mjs
+++ b/app/pages/events/$id.mjs
@@ -10,8 +10,6 @@ export default function ({ html, state = {} }) {
   let hasSponsors = sponsors && sponsors.length > 0
   if (display === "email") {
     let eventDate = new Date(date)
-    // this xmp tag is a hack, detailed in this stackoverflow answer:
-    // https://stackoverflow.com/a/16785992
     let htmlContents = `
       <p>GREETING TEXT</p>
       <!-- sponsor -->
@@ -45,7 +43,6 @@ export default function ({ html, state = {} }) {
       </style>
       <div class="container">
         <button id="copy-html-btn">Copy HTML to clipboard</button>
-
         ${htmlContents}
         <script>
          const copyHTML = async () => {

--- a/app/pages/events/$id.mjs
+++ b/app/pages/events/$id.mjs
@@ -10,28 +10,6 @@ export default function ({ html, state = {} }) {
   if (display === "email") {
     let eventDate = new Date(date)
     let htmlContents = `
-      <p>GREETING TEXT</p>
-      <!-- sponsor -->
-      ${hasSponsors ? sponsors.map(s => `
-        <p>
-          <a href="${s.url}"><img width="200" alt="${s.name} logo" src="https://seattlejs.com/_public/images/sponsors/${s.image}" title="${s.name} logo"></a>
-        </p>
-        <p>Special thanks to our friends at <a href="URL">${s.name}</a> for sponsoring snacks for this month's event! 😎</p>
-      `).join('') : null}
-      <ul>
-        <li>🗓 ${eventDate.toLocaleDateString(undefined, {weekday: "long", month: "long", day: "numeric"})}</li>
-        <li>⏰ 5:30pm - 8:30pm</li>
-        <li>📍 LOCATION</li>
-        <li>🎟 <a href="https://ti.to/event-loop/">Buy Tickets</a></li>
-      </ul>
-      <! -- loop through talks -->
-      ${hasTalks ? talks.map(t => `
-          <h4 style="font-family: headline-gothic-atf-round, sans-serif; font-weight: 700; font-size: 24px;">${t.title} by ${t.speaker.name}</h4>
-          <p><img width="200" alt="${t.name}" src="https://seattlejs.com/_public/images/speakers/${t.speaker.photo}" title="${t.speaker.name}"></p>
-          ${description && `<p>${marked(description)}</p>` }
-        `).join('') : null }
-      <!-- end loop -->
-      <p>See you all on ${eventDate.toLocaleDateString(undefined, {month: "long", day: "numeric"})}</p>
     `
     return html`
       <style>
@@ -42,15 +20,38 @@ export default function ({ html, state = {} }) {
       </style>
       <div class="container">
         <button id="copy-html-btn">Copy HTML to clipboard</button>
-        ${htmlContents}
+        <div id="html-contents">
+          <p>GREETING TEXT</p>
+          <!-- sponsor -->
+          ${hasSponsors ? sponsors.map(s => `
+            <p>
+              <a href="${s.url}"><img width="200" alt="${s.name} logo" src="https://seattlejs.com/_public/images/sponsors/${s.image}" title="${s.name} logo"></a>
+            </p>
+            <p>Special thanks to our friends at <a href="URL">${s.name}</a> for sponsoring snacks for this month's event! 😎</p>
+          `).join('') : null}
+          <ul>
+            <li>🗓 ${eventDate.toLocaleDateString(undefined, {weekday: "long", month: "long", day: "numeric"})}</li>
+            <li>⏰ 5:30pm - 8:30pm</li>
+            <li>📍 LOCATION</li>
+            <li>🎟 <a href="https://ti.to/event-loop/">Buy Tickets</a></li>
+          </ul>
+          <! -- loop through talks -->
+          ${hasTalks ? talks.map(t => `
+              <h4 style="font-family: headline-gothic-atf-round, sans-serif; font-weight: 700; font-size: 24px;">${t.title} by ${t.speaker.name}</h4>
+              <p><img width="200" alt="${t.name}" src="https://seattlejs.com/_public/images/speakers/${t.speaker.photo}" title="${t.speaker.name}"></p>
+              ${description && `<p>${marked(description)}</p>` }
+            `).join('') : null }
+          <!-- end loop -->
+          <p>See you all on ${eventDate.toLocaleDateString(undefined, {month: "long", day: "numeric"})}</p>
+        </div>
         <script>
-         const copyHTML = async () => {
-          console.log(\`${htmlContents}\`)
-          await navigator.clipboard.writeText(\`${htmlContents}\`);
+        const copyHTML = async () => {
+          const holder = document.getElementById("html-contents")
+          await navigator.clipboard.writeText(holder.innerHTML)
         }
         window.addEventListener("DOMContentLoaded", () => {
           const htmlButton = document.getElementById("copy-html-btn")
-          htmlButton.addEventListener("click", copyHTML)
+          htmlButton.addEventListener("click", copyHTML2)
         })
         </script>
       </div>

--- a/app/pages/events/$id.mjs
+++ b/app/pages/events/$id.mjs
@@ -1,4 +1,4 @@
-import { marked } from "marked"
+import { marked } from 'marked'
 
 export default function ({ html, state = {} }) {
   let { store = {} } = state
@@ -7,31 +7,60 @@ export default function ({ html, state = {} }) {
   let { id, title, sponsors, talks, description, date } = event
   let hasTalks = talks && talks.length > 0
   let hasSponsors = sponsors && sponsors.length > 0
-  if (display === "email") {
+  if (display === 'email') {
     let eventDate = new Date(date)
     let htmlContents = `
       <p>GREETING TEXT</p>
       <!-- sponsor -->
-      ${hasSponsors ? sponsors.map(s => `
+      ${
+        hasSponsors
+          ? sponsors
+              .map(
+                s => `
         <p>
           <a href="${s.url}"><img width="200" alt="${s.name} logo" src="https://seattlejs.com/_public/images/sponsors/${s.image}" title="${s.name} logo"></a>
         </p>
         <p>Special thanks to our friends at <a href="URL">${s.name}</a> for sponsoring snacks for this month's event! 😎</p>
-      `).join('') : null}
+      `
+              )
+              .join('')
+          : null
+      }
       <ul>
-        <li>🗓 ${eventDate.toLocaleDateString(undefined, {weekday: "long", month: "long", day: "numeric"})}</li>
+        <li>🗓 ${eventDate.toLocaleDateString(undefined, {
+          weekday: 'long',
+          month: 'long',
+          day: 'numeric'
+        })}</li>
         <li>⏰ 5:30pm - 8:30pm</li>
         <li>📍 LOCATION</li>
         <li>🎟 <a href="https://ti.to/event-loop/">Buy Tickets</a></li>
       </ul>
       <! -- loop through talks -->
-      ${hasTalks ? talks.map(t => `
-          <h4 style="font-family: headline-gothic-atf-round, sans-serif; font-weight: 700; font-size: 24px;">${t.title} by ${t.speaker.name}</h4>
-          <p><img width="200" alt="${t.name}" src="https://seattlejs.com/_public/images/speakers/${t.speaker.photo}" title="${t.speaker.name}"></p>
-          ${description && `<p>${marked(description)}</p>` }
-        `).join('') : null }
+      ${
+        hasTalks
+          ? talks
+              .map(
+                t => `
+          <h4 style="font-family: headline-gothic-atf-round, sans-serif; font-weight: 700; font-size: 24px;">${
+            t.title
+          } by ${t.speaker.name}</h4>
+          <p><img width="200" alt="${
+            t.name
+          }" src="https://seattlejs.com/_public/images/speakers/${
+                  t.speaker.photo
+                }" title="${t.speaker.name}"></p>
+          ${description && `<p>${marked(description)}</p>`}
+        `
+              )
+              .join('')
+          : null
+      }
       <!-- end loop -->
-      <p>See you all on ${eventDate.toLocaleDateString(undefined, {month: "long", day: "numeric"})}</p>
+      <p>See you all on ${eventDate.toLocaleDateString(undefined, {
+        month: 'long',
+        day: 'numeric'
+      })}</p>
     `
     return html`
       <style>
@@ -44,25 +73,27 @@ export default function ({ html, state = {} }) {
         <button id="copy-html-btn">Copy HTML to clipboard</button>
         ${htmlContents}
         <script>
-         const copyHTML = async () => {
-          console.log(\`${htmlContents}\`)
-          await navigator.clipboard.writeText(\`${htmlContents}\`);
-        }
-        window.addEventListener("DOMContentLoaded", () => {
-          const htmlButton = document.getElementById("copy-html-btn")
-          htmlButton.addEventListener("click", copyHTML)
-        })
+          const copyHTML = async () => {
+            console.log(\`${htmlContents}\`)
+            await navigator.clipboard.writeText(\`${htmlContents}\`)
+          }
+          window.addEventListener('DOMContentLoaded', () => {
+            const htmlButton = document.getElementById('copy-html-btn')
+            htmlButton.addEventListener('click', copyHTML)
+          })
         </script>
       </div>
     `
   }
   return html`
-  <page-layout title=${title}>
+    <page-layout title=${title}>
       <h3>${title}</h3>
-      ${description && `<p>${marked(description)}</p>` }
+      ${description && `<p>${marked(description)}</p>`}
       <h4>Thanks to our Sponsors ❤️</h4>
       ${hasSponsors ? html`<list-sponsors></list-sponsors>` : null}
-      ${hasTalks ? html`<list-talks event_id="${id}"></list-talks>`: html`<p>No talks were given durring this event.</p>`}
+      ${hasTalks
+        ? html`<list-talks event_id="${id}"></list-talks>`
+        : html`<p>No talks were given durring this event.</p>`}
       <div class="">
         <a target="_self" href="/events">
           See all past events <i class="fa-solid fa-arrow-right"></i>
@@ -71,4 +102,3 @@ export default function ({ html, state = {} }) {
     </page-layout>
   `
 }
-

--- a/app/pages/events/$id.mjs
+++ b/app/pages/events/$id.mjs
@@ -25,7 +25,7 @@ export default function ({ html, state = {} }) {
             <p>
               <a href="${s.url}"><img width="200" alt="${s.name} logo" src="https://seattlejs.com/_public/images/sponsors/${s.image}" title="${s.name} logo"></a>
             </p>
-            <p>Special thanks to our friends at <a href="URL">${s.name}</a> for sponsoring snacks for this month's event! 😎</p>
+            <p>Special thanks to our friends at <a href="${s.url}">${s.name}</a> for sponsoring snacks for this month's event! 😎</p>
           `).join('') : null}
           <ul>
             <li>🗓 ${eventDate.toLocaleDateString(undefined, {weekday: "long", month: "long", day: "numeric"})}</li>
@@ -36,7 +36,7 @@ export default function ({ html, state = {} }) {
           <! -- loop through talks -->
           ${hasTalks ? talks.map(t => `
               <h4 style="font-family: headline-gothic-atf-round, sans-serif; font-weight: 700; font-size: 24px;">${t.title} by ${t.speaker.name}</h4>
-              <p><img width="200" alt="${t.name}" src="https://seattlejs.com/_public/images/speakers/${t.speaker.photo}" title="${t.speaker.name}"></p>
+              <p><img width="200" alt="${t.title}" src="https://seattlejs.com/_public/images/speakers/${t.speaker.photo}" title="${t.speaker.name}"></p>
               ${description && `<p>${marked(description)}</p>` }
             `).join('') : null }
           <!-- end loop -->

--- a/app/pages/events/$id.mjs
+++ b/app/pages/events/$id.mjs
@@ -3,9 +3,63 @@ import { marked } from "marked"
 export default function ({ html, state = {} }) {
   let { store = {} } = state
   let event = store.events[0]
-  let { id, title, sponsors, talks, description } = event
+  let display = store.display
+  let { id, title, sponsors, talks, description, date } = event
   let hasTalks = talks && talks.length > 0
+  console.log({hasTalks})
   let hasSponsors = sponsors && sponsors.length > 0
+  if (display === "email") {
+    let eventDate = new Date(date)
+    // this xmp tag is a hack, detailed in this stackoverflow answer:
+    // https://stackoverflow.com/a/16785992
+    let htmlContents = `
+      <p>GREETING TEXT</p>
+      <!-- sponsor -->
+      ${hasSponsors ? sponsors.map(s => `
+        <p>
+          <a href="${s.url}"><img width="200" alt="${s.name} logo" src="https://seattlejs.com/_public/images/sponsors/${s.image}" title="${s.name} logo"></a>
+        </p>
+        <p>Special thanks to our friends at <a href="URL">${s.name}</a> for sponsoring snacks for this month's event! 😎</p>
+      `).join('') : null}
+      <ul>
+        <li>🗓 ${eventDate.toLocaleDateString(undefined, {weekday: "long", month: "long", day: "numeric"})}</li>
+        <li>⏰ 5:30pm - 8:30pm</li>
+        <li>📍 LOCATION</li>
+        <li>🎟 <a href="https://ti.to/event-loop/">Buy Tickets</a></li>
+      </ul>
+      <! -- loop through talks -->
+      ${hasTalks ? talks.map(t => `
+          <h4 style="font-family: headline-gothic-atf-round, sans-serif; font-weight: 700; font-size: 24px;">${t.title} by ${t.speaker.name}</h4>
+          <p><img width="200" alt="${t.name}" src="https://seattlejs.com/_public/images/speakers/${t.speaker.photo}" title="${t.speaker.name}"></p>
+          ${description && `<p>${marked(description)}</p>` }
+        `).join('') : null }
+      <!-- end loop -->
+      <p>See you all on ${eventDate.toLocaleDateString(undefined, {month: "long", day: "numeric"})}</p>
+    `
+    return html`
+      <style>
+        .container {
+          display: block;
+          margin: 20px;
+        }
+      </style>
+      <div class="container">
+        <button id="copy-html-btn">Copy HTML to clipboard</button>
+
+        ${htmlContents}
+        <script>
+         const copyHTML = async () => {
+          console.log(\`${htmlContents}\`)
+          await navigator.clipboard.writeText(\`${htmlContents}\`);
+        }
+        window.addEventListener("DOMContentLoaded", () => {
+          const htmlButton = document.getElementById("copy-html-btn")
+          htmlButton.addEventListener("click", copyHTML)
+        })
+        </script>
+      </div>
+    `
+  }
   return html`
   <page-layout title=${title}>
       <h3>${title}</h3>
@@ -21,3 +75,4 @@ export default function ({ html, state = {} }) {
     </page-layout>
   `
 }
+


### PR DESCRIPTION
Solves #112  item 3

This PR allows us to generate email templates for an event page.

Some email clients allow pasting rendered html content from the clipboard, so it's good to have the rendered version of the email on the page. See the below screenshot for an example of what the page looks like. Organizers can copypaste the email contents by starting their selection just below the "copy html" button or use the button to grab the raw html.

![image](https://github.com/seattlejs/seattlejs.com/assets/40310772/eafc09ac-a648-4f64-af34-356347e8fd9a)
