### PR TITLE
Clarify install section to include Begin CLI installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,11 @@ If there is no Markdown file that matches the path, a 404 error will be returned
 
 - clone this repo
 - `npm i`
+- install the Begin CLI, see instructions [here](https://begin.com/docs/getting-started/installing-the-begin-cli)
 
 ## Setup
 
 If you need to run/test the mailing list subscription action (`POST /signup`) you will need to configure the following environment variables: `CIO_SITE_ID`, `CIO_API_KEY`, `CIO_APP_KEY`
-
-### Begin Setup
-
-Once again this app uses [Begin](https://begin.com) for its deployments.  You will have to install the Begin CLI before running the start script as outlined [here](https://begin.com/docs/getting-started/installing-the-begin-cli).
 
 ## Run dev server
 


### PR DESCRIPTION
This PR moves the Begin CLI setup into the installation section. I ran into a problem the other day where I didn't read past the email setup and got stuck on missing the Begin CLI for a while. Admittedly this is only a problem if you don't fully read the instructions, but I'd imagine this might trip up others as well.

I considered keeping the section with the begin setup in addition to the install step, and maybe renaming it "Deployments" or something like that, but our deployments are automated and it's mentioned earlier, so it shouldn't be necessary.